### PR TITLE
update bacongobbler azure blob upload ref

### DIFF
--- a/.github/workflows/webflow-azure-blobstorage-upload.yml
+++ b/.github/workflows/webflow-azure-blobstorage-upload.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           replacement_file: ${{ inputs.replacement_file }}
           dir: "unzipped"
-      - uses: bacongobbler/azure-blob-storage-upload@874139251d8ba621ed4080cce9b5ebd0fcc019a2
+      - uses: bacongobbler/azure-blob-storage-upload@ec64da8ff7ee6a813893cd3d68a7e360b93c5484
         with:
           source_dir: "unzipped"
           container_name: "$web"

--- a/.github/workflows/webflow-azure-blobstorage-upload.yml
+++ b/.github/workflows/webflow-azure-blobstorage-upload.yml
@@ -34,3 +34,4 @@ jobs:
           container_name: "$web"
           connection_string: ${{ secrets.connection_string }}
           sync: "true"
+          cli_version: "2.42.0"


### PR DESCRIPTION
There was a new release of the azure cli. The
[azure-blob-storage-upload](https://github.com/bacongobbler/azure-blob-storage-upload) we are using doesn't (by default) fix the version of the cli to use. So it used the newest one which broke our action.

The issue was resolved by using the newest version of [azure-blob-storage-upload](https://github.com/bacongobbler/azure-blob-storage-upload)(i.e., referencing the newest commit). To prevent this from happening again, I also specified that the action should always use the same azure-cli version.