### PR TITLE
Update workflow runner tags

### DIFF
--- a/.github/workflows/yarn_build_docker_publish_self_hosted.yml
+++ b/.github/workflows/yarn_build_docker_publish_self_hosted.yml
@@ -72,7 +72,7 @@ on:
 jobs:
   build:
     name: Build Project
-    runs-on: ["self-hosted", "linux"]
+    runs-on: ["self-hosted", "linux", "stable"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/yarn_build_self_hosted.yml
+++ b/.github/workflows/yarn_build_self_hosted.yml
@@ -54,7 +54,7 @@ on:
 jobs:
   build:
     name: Build Project
-    runs-on: ["self-hosted", "linux"]
+    runs-on: ["self-hosted", "linux", "stable"]
     steps:
       - name: Setup Nodejs and npm
         uses: actions/setup-node@v3


### PR DESCRIPTION
Wir haben jetzt einen `stable`  Tag auf unseren Runners im Büro. Damit wird verhindert, dass Jobs auf dem falschen Runner laufen wenn wir andere Runner deployen.